### PR TITLE
Support Ghostty

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Encodes images to iTerm / Kitty / SIXEL (terminal) inline graphics protocols.
 | terminal       | response                                            |
 | :----          | :----                                               |
 | apple terminal | `\x1b[?1;2c`                                        |
+| ghostty        | `\x1b[?62;22c`                                      |
 | guake          | `\x1b[?65;1;9c`                                     |
 | iterm2         | `\x1b[?62;4c`                                       |
 | kitty          | `\x1b[?62;c`                                        |
@@ -75,6 +76,7 @@ Encodes images to iTerm / Kitty / SIXEL (terminal) inline graphics protocols.
 | terminal       | response            |
 | :----          | :----               |
 | apple terminal | `\x1b[>1;95;0c`     |
+| ghostty        | `\x1b[>1;10;0c`     |
 | guake          | `\x1b[>65;5402;1c`  |
 | iterm2         | `\x1b[>0;95;0c`     |
 | kitty          | `\x1b[>1;4000;19c`  |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Encodes images to iTerm / Kitty / SIXEL (terminal) inline graphics protocols.
 
 | terminal | sixel | iTerm2 format | kitty format |
 | :---     | :--:  | :--:          | :--:         |
+| ghostty  |       |               | Y            |
 | iterm2   | Y     | Y             |              |
 | kitty    |       |               | Y            |
 | mintty   | Y     | Y             |              |
@@ -93,6 +94,7 @@ Encodes images to iTerm / Kitty / SIXEL (terminal) inline graphics protocols.
 | :----          | :----                                       |
 | apple terminal | `TERM_PROGRAM="Apple_Terminal"            ` |
 | apple terminal | `__CFBundleIdentifier="com.apple.Terminal"` |
+| ghostty        | `TERM="xterm-ghostty"                     ` |
 | guake          | `                                         ` |
 | iterm2         | `LC_TERMINAL="iTerm2"                     ` |
 | kitty          | `TERM="xterm-kitty"                       ` |

--- a/kitty.go
+++ b/kitty.go
@@ -71,7 +71,7 @@ func IsKittyCapable() bool {
 
 	// TODO: more rigorous check
 	V := GetEnvIdentifiers()
-	return (len(V["KITTY_WINDOW_ID"]) > 0) || (V["TERM_PROGRAM"] == "wezterm")
+	return (len(V["KITTY_WINDOW_ID"]) > 0) || (V["TERM_PROGRAM"] == "wezterm") || (V["TERM_PROGRAM"] == "ghostty")
 }
 
 // Display local PNG file


### PR DESCRIPTION
The new kid on the block, [Ghostty](https://ghostty.org/), supports the [Kitty graphics protocol](https://ghostty.org/docs/features).

This should enable rasterm to support it.

Test output:

<img width="772" alt="image" src="https://github.com/user-attachments/assets/2ba7eb5d-8c6d-4f3d-98cb-8ba5ae3e78c0" />
